### PR TITLE
feat: add space between roku name and switch names

### DIFF
--- a/src/__tests__/homebridge-roku.test.js
+++ b/src/__tests__/homebridge-roku.test.js
@@ -115,7 +115,7 @@ describe('homebridge-roku', () => {
     });
 
     it('should have proper service and name set', () => {
-      expect(powerSwitch.service).toEqual('RokuPower');
+      expect(powerSwitch.service).toEqual('Roku Power');
       expect(powerSwitch.name).toEqual('Power');
     });
 
@@ -196,7 +196,7 @@ describe('homebridge-roku', () => {
       });
 
       it('should have the proper service and name', () => {
-        expect(keySwitch.service).toEqual(`Roku${keypress}`);
+        expect(keySwitch.service).toEqual(`Roku ${keypress}`);
         expect(keySwitch.name).toEqual(keypress);
       });
 
@@ -241,7 +241,7 @@ describe('homebridge-roku', () => {
       });
 
       it('should have proper service and name', () => {
-        expect(channelSwitch.service).toEqual(`Roku${channel}`);
+        expect(channelSwitch.service).toEqual(`Roku ${channel}`);
         expect(channelSwitch.name).toEqual(`${channel}`);
       });
 

--- a/src/homebridge-roku.js
+++ b/src/homebridge-roku.js
@@ -49,7 +49,7 @@ class RokuAccessory {
   }
 
   setupSwitch() {
-    const switch_ = new Service.Switch(`${this.name}Power`, 'Power');
+    const switch_ = new Service.Switch(`${this.name} Power`, 'Power');
 
     switch_
       .getCharacteristic(Characteristic.On)
@@ -67,7 +67,7 @@ class RokuAccessory {
 
   setupMute() {
     // Speaker seems to be unsupported, emmulating with a switch
-    const volume = new Service.Switch(`${this.name}Mute`, 'Mute');
+    const volume = new Service.Switch(`${this.name} Mute`, 'Mute');
 
     volume
       .getCharacteristic(Characteristic.On)
@@ -99,7 +99,7 @@ class RokuAccessory {
 
   setupVolume(key) {
     const volume = new Service.Switch(
-      `${this.name}${key.command}`,
+      `${this.name} ${key.command}`,
       key.command,
     );
 
@@ -123,7 +123,7 @@ class RokuAccessory {
   }
 
   setupChannel(name, id) {
-    const channel = new Service.Switch(`${this.name}${name}`, name);
+    const channel = new Service.Switch(`${this.name} ${name}`, name);
 
     channel
       .getCharacteristic(Characteristic.On)


### PR DESCRIPTION
This makes the names a bit more ergonomic in the home app. Instead of
RokuPower, it will now be Roku Power, etc.