### PR TITLE
feat: allow configuring volume increment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ improvements.
 * Turn on RokuNetflix
 * Turn on Roku{app name}
 
+## Configuration
+
+The amount that volume will be increased or decreased per volume up/down command
+can be set in the config. By default, both up and down will be done in
+increments of 5. To change this, there are two settings: `volumeIncrement` and
+`volumeDecrement`. If only `volumeIncrement` is set, then both volume up and
+down will change by the same abount.
+
 ## Helping Out
 
 There are many versions of Roku devices, each with a different feature set.

--- a/src/__tests__/homebridge-roku.test.js
+++ b/src/__tests__/homebridge-roku.test.js
@@ -206,7 +206,7 @@ describe('homebridge-roku', () => {
         expect(getMock).toHaveBeenCalledWith(null, false);
       });
 
-      it(`should call ${keypress} 10 times on set`, done => {
+      it(`should call ${keypress} 5 times on set`, done => {
         on._events.set(true, (val1, val2) => {
           expect(val1).toBeNull();
           expect(val2).toBeFalsy();
@@ -216,11 +216,54 @@ describe('homebridge-roku', () => {
             keypress,
             keypress,
             keypress,
-            keypress,
-            keypress,
-            keypress,
-            keypress,
-            keypress,
+          ]);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('volumeIncrement setting', () => {
+    it('should call VolumeUp/Down based on the volumeIncrement setting', done => {
+      config.volumeIncrement = 2;
+      accessory = new Accessory(() => {}, config);
+      const upSwitch = accessory.services[3];
+      const downSwitch = accessory.services[4];
+      const upOn = upSwitch.getCharacteristic('on');
+      const downOn = downSwitch.getCharacteristic('on');
+
+      upOn._events.set(true, () => {
+        downOn._events.set(true, () => {
+          expect(accessory.roku._keys).toEqual([
+            'VolumeUp',
+            'VolumeUp',
+            'VolumeDown',
+            'VolumeDown',
+          ]);
+          done();
+        });
+      });
+    });
+
+    it('should allow setting VolumeUp/Down independently', done => {
+      config.volumeIncrement = 4;
+      config.volumeDecrement = 3;
+      accessory = new Accessory(() => {}, config);
+      const upSwitch = accessory.services[3];
+      const downSwitch = accessory.services[4];
+      const upOn = upSwitch.getCharacteristic('on');
+      const downOn = downSwitch.getCharacteristic('on');
+
+      upOn._events.set(true, () => {
+        downOn._events.set(true, () => {
+          expect(accessory.roku._keys).toEqual([
+            'VolumeUp',
+            'VolumeUp',
+            'VolumeUp',
+            'VolumeUp',
+            'VolumeDown',
+            'VolumeDown',
+            'VolumeDown',
           ]);
           done();
         });

--- a/src/homebridge-roku.js
+++ b/src/homebridge-roku.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const DEFAULT_VOLUME_INCREMENT = 5;
+
 const { Client, keys } = require('roku-client');
 const map = require('lodash.map');
 
@@ -19,6 +21,9 @@ class RokuAccessory {
     this.info = config.info;
     this.roku = new Client(config.ip);
     this.services = [];
+
+    this.volumeIncrement = config.volumeIncrement || DEFAULT_VOLUME_INCREMENT;
+    this.volumeDecrement = config.volumeDecrement || this.volumeIncrement;
 
     this.muted = false;
     this.volumeLevel = 50;
@@ -90,14 +95,14 @@ class RokuAccessory {
   }
 
   setupVolumeUp() {
-    return this.setupVolume(keys.VOLUME_UP);
+    return this.setupVolume(keys.VOLUME_UP, this.volumeIncrement);
   }
 
   setupVolumeDown() {
-    return this.setupVolume(keys.VOLUME_DOWN);
+    return this.setupVolume(keys.VOLUME_DOWN, this.volumeDecrement);
   }
 
-  setupVolume(key) {
+  setupVolume(key, increment) {
     const volume = new Service.Switch(
       `${this.name} ${key.command}`,
       key.command,
@@ -109,7 +114,7 @@ class RokuAccessory {
       .on('set', (value, callback) => {
         this.roku
           .command()
-          .keypress(key, 10)
+          .keypress(key, increment)
           .send()
           .then(() => callback(null, false))
           .catch(callback);


### PR DESCRIPTION
Change default volume increment to 5 instead of 10, and allow it to be
configured from the homebridge config.