### PR TITLE
[VERY early WIP] Adopt HAP Television Services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -636,6 +636,11 @@
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
+    "array-flatten": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
+    },
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -1104,10 +1109,28 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bindings": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
       "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+    },
+    "bonjour-hap": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.5.1.tgz",
+      "integrity": "sha512-JqJXX5+i1NRGt8GyIPb+nBNjwrHbWe5Pb+HSuRMG/B62tPRHQ4Jyv3yX7hy1pHfRrV2OhnWpd+ljBtMb24R5rA==",
+      "requires": {
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1167,6 +1190,16 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
+    },
+    "buffer-indexof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -2001,6 +2034,15 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "curve25519-n": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/curve25519-n/-/curve25519-n-1.4.0.tgz",
+      "integrity": "sha512-ihQ3M/Aj9PVbsNwuul1/PNnyFurl9ejZGJWw/361+SS9hEFLiM2ttde+BXiu3ooc4AQiIx2y1gEcGLTpLRAjKg==",
+      "requires": {
+        "bindings": "~1.3.0",
+        "nan": "^2.10.0"
+      }
+    },
     "dargs": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
@@ -2081,11 +2123,21 @@
         }
       }
     },
+    "decimal.js": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-7.5.1.tgz",
+      "integrity": "sha512-1K5Y6MykxQYfHBcFfAj2uBaLmwreq4MsjsvrlgcEOvg+X82IeeXlIVIVkBMiypksu+yo9vcYP6lfU3qTedofSQ=="
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2207,6 +2259,28 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "dns-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
+    },
+    "dns-packet": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "requires": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "dns-txt": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+      "requires": {
+        "buffer-indexof": "^1.0.0"
+      }
+    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2252,6 +2326,15 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ed25519-hap": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ed25519-hap/-/ed25519-hap-0.0.5.tgz",
+      "integrity": "sha512-6RPUW9BdnUjYz5lGjRfM0sOMa8d43sjWFFchGJhGKkevoZvB0oVp1ES9oDUK+QJoJO8EoJlgawNsxG2yvlMbYg==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.10.0"
       }
     },
     "end-of-stream": {
@@ -2785,6 +2868,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-srp-hap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-1.0.1.tgz",
+      "integrity": "sha1-N3Ek0Za8alFXquWze/X6NbtK0tk="
     },
     "fb-watchman": {
       "version": "2.0.0",
@@ -3872,6 +3960,37 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        }
+      }
+    },
+    "hap-nodejs": {
+      "version": "0.4.48",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.4.48.tgz",
+      "integrity": "sha512-z4Lyck7cTUcrcQ9EtJUqjRqh1+NRNAu0JWvqiYu31cA76A7AZV2EXuW57+ebxhFyYwh298/4KAiE8sM0ClX11w==",
+      "requires": {
+        "bonjour-hap": "^3.5.1",
+        "buffer-shims": "^1.0.0",
+        "curve25519-n": "^1.2.0",
+        "debug": "^2.2.0",
+        "decimal.js": "^7.2.3",
+        "ed25519-hap": "^0.0.5",
+        "fast-srp-hap": "^1.0.1",
+        "ip": "^1.1.3",
+        "node-persist": "^0.0.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -5603,7 +5722,6 @@
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -5611,8 +5729,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -5627,6 +5744,20 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
+    "multicast-dns": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+      "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+      "requires": {
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
+      }
+    },
+    "multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -5636,9 +5767,7 @@
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5712,6 +5841,22 @@
         "semver": "^5.5.0",
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
+      }
+    },
+    "node-persist": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.11.tgz",
+      "integrity": "sha1-1m66Pr72IPB5Uw+nsTB2qQZmWHQ=",
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "q": "~1.1.1"
+      },
+      "dependencies": {
+        "q": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+          "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok="
+        }
       }
     },
     "node-ssdp": {
@@ -6661,8 +6806,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -7782,6 +7926,11 @@
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
+    },
+    "thunky": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
+      "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "deepmerge": "^3.0.0",
+    "hap-nodejs": "^0.4.48",
     "lodash.map": "^4.6.0",
     "roku-client": "^3.1.3"
   },

--- a/src/homebridge-roku.js
+++ b/src/homebridge-roku.js
@@ -5,6 +5,7 @@ const DEFAULT_VOLUME_INCREMENT = 5;
 const { Client, keys } = require('roku-client');
 const map = require('lodash.map');
 const tlv = require('hap-nodejs/lib/util/tlv');
+const plugin = require('../package');
 
 let Service;
 let Characteristic;
@@ -64,10 +65,11 @@ class RokuAccessory {
     const accessoryInfo = new Service.AccessoryInformation();
 
     accessoryInfo
-      .setCharacteristic(Characteristic.Manufacturer, this.info.vendorName)
+      .setCharacteristic(Characteristic.Manufacturer, this.info.vendorName || 'Roku, Inc.')
+      .setCharacteristic(Characteristic.Name, this.info.friendlyModelName || 'Roku')
       .setCharacteristic(Characteristic.Model, this.info.modelName)
-      .setCharacteristic(Characteristic.Name, this.info.userDeviceName)
-      .setCharacteristic(Characteristic.SerialNumber, this.info.serialNumber);
+      .setCharacteristic(Characteristic.SerialNumber, this.info.serialNumber)
+      .setCharacteristic(Characteristic.FirmwareRevision, this.info.softwareVersion || plugin.version);
 
     return accessoryInfo;
   }

--- a/src/homebridge-roku.js
+++ b/src/homebridge-roku.js
@@ -32,7 +32,6 @@ class RokuAccessory {
     this.volumeDecrement = config.volumeDecrement || this.volumeIncrement;
 
     this.muted = false;
-    this.poweredOn = Characteristic.Active.INACTIVE;
 
     this.buttons = {
       [Characteristic.RemoteKey.REWIND]: keys.REVERSE,
@@ -83,21 +82,22 @@ class RokuAccessory {
           .info()
           .then((info) => {
             const value = info.powerMode === 'PowerOn' ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
-            this.poweredOn = value;
             callback(null, value);
           })
           .catch(callback);
       })
       .on('set', (newValue, callback) => {
-        if (newValue == this.poweredOn) {
-          callback(null);
-          return;
+        if (newValue === Characteristic.Active.ACTIVE) {
+          this.roku
+            .keypress('PowerOn')
+            .then(() => callback(null))
+            .catch(callback);
+        } else {
+          this.roku
+            .keypress('PowerOff')
+            .then(() => callback(null))
+            .catch(callback);
         }
-        this.poweredOn = newValue;
-        this.roku
-          .keypress('Power')
-          .then(() => callback(null))
-          .catch(callback);
       })
 
     television

--- a/src/setup.js
+++ b/src/setup.js
@@ -17,23 +17,23 @@ function generateConfig() {
   return Client.discover()
     .then(device => {
       const { ip } = device;
-      const appMap = {};
+      const inputs = [];
       return device
         .apps()
         .then(apps =>
           apps.forEach(app => {
-            appMap[app.name] = app.id;
+            inputs.push({ id: app.id, name: app.name });
           }),
         )
         .then(() => device.info())
-        .then(info => ({ ip, appMap, info }));
+        .then(info => ({ ip, inputs, info }));
     })
-    .then(({ ip, appMap, info }) => ({
+    .then(({ ip, inputs, info }) => ({
       accessories: [
         {
           ip,
           info,
-          appMap,
+          inputs,
           name: 'Roku',
           accessory: 'Roku',
         },


### PR DESCRIPTION
This is the result of an evening's hacking: a rough-cut first pass at using the new HAP services for televisions, television speakers, and television input sources.

I don't intend for this to be merged as-is and am posting it to seek early feedback. iOS 12.2 is only just now in beta, and the HAP pieces can still change. If we're lucky, though, this may save someone else some time if they're seeking to experiment too. I'm running this on an RPi in my home currently and will see how it behaves over the next week or so.

Some high points and notes:

- The configuration now accepts inputs (née apps) as an ordered list of pairs. HAP identifies inputs by an `Int32`, so we need stable indices. Preserving the order of the config file also allows relaying that order to the UI, rather than it sorting by the inputs' names.
  * HAP seems to have support for updating the sort order, but I haven't been able to get that to trigger UI in iOS. I might be misconfiguring it, or it might not be implemented yet.
- Power on/off works as expected.
- Button input works and maps to almost all the non-advertising buttons on the Roku remote.
- Input switching lists all the apps/inputs on the Roku home screen and switching between them works as expected.
- Volume up/down works as expected.
- I can't figure out how to mute in iOS. I might be misconfiguring it, or it might not be implemented yet.

[Here's a cool little video of it.](https://mobile.twitter.com/zwaldowski/status/1089059079333531648)

And some screenshots:

![img_0228](https://user-images.githubusercontent.com/170812/51784391-e74b1c80-2115-11e9-82d7-880e55cf8c2e.PNG)
![img_0227](https://user-images.githubusercontent.com/170812/51784392-e74b1c80-2115-11e9-9dbd-3fe91d8884e8.PNG)
![img_0225](https://user-images.githubusercontent.com/170812/51784393-e74b1c80-2115-11e9-8ab1-d1ec91cf5704.PNG)