### PR TITLE
Wake on Lan

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ homebridge config for your Roku accessory: `"infoButtonOverride": "HOME"`. The
 list of possible keys can be found
 [here](https://github.com/bschlenk/node-roku-client/blob/master/lib/keys.ts).
 
+### requestTimeout
+
+Wait for this value in milliseconds before considering the device unreachable. The default value is 1000 (1 second).
+
 ## Migrating Major Versions
 
 ### 2.x.x -> 3.x.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -8794,8 +8794,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "2.3.0",
@@ -8813,6 +8812,14 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -10813,6 +10820,11 @@
         "has-symbols": "^1.0.1",
         "is-typed-array": "^1.1.3"
       }
+    },
+    "wol": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/wol/-/wol-1.0.7.tgz",
+      "integrity": "sha512-kg7ETY8g3V5+3GVhUfWCVjeXuCmfrX6xfw4cw4c88+MtoxkbFmcs9Y5yhT1wwOL8inogFUQZ8JMzH9OekaaawQ=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   "dependencies": {
     "deepmerge": "^4.2.2",
     "lodash.map": "^4.6.0",
-    "roku-client": "^4.0.0"
+    "p-timeout": "^3.2.0",
+    "roku-client": "^4.0.0",
+    "wol": "^1.0.7"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",


### PR DESCRIPTION
Related to #4.

I believe the information in the above issue may be outdated, or my TV may just be different (2020 series 6). My situation:
- There is no 'eco mode' but some called 'fast start' instead, which is effectively the same? When fast start is enabled, the TV is always accessible over the network. When disabled, the TV disconnects from the network after 15 minutes.
- However, when in fast start mode it constantly pulls 30 W which would be nice to avoid.
- The TV does not advertise on the `/device-info` endpoint that WoL is supported.
- But empirically WoL **does work** when the TV is **not** in fast start mode.

So the TL;DR is that adding WoL support helps lower my energy bill while still allowing HomeKit to turn on my TV. 😛

It's a fairly naive implementation right now but seems to work well. One caveat is that scenes which change the input and turn on the TV at the same time don't work if the TV is offline; but that doesn't seem like a dealbreaker.

I started adding tests but then realized that many were skipped. Is that something you want me to still do?